### PR TITLE
Bugfix - Ticket get does not implement TicketResponse struct

### DIFF
--- a/ticket.go
+++ b/ticket.go
@@ -274,13 +274,13 @@ func (s *TicketService) Get(id string) (*Ticket, *Response, error) {
 		return nil, nil, err
 	}
 
-	ticket := &Ticket{}
-	resp, err := s.client.Do(req, &ticket)
+	response := &TicketResponse{}
+	resp, err := s.client.Do(req, &response)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return ticket, resp, err
+	return &response.Ticket, resp, err
 }
 
 // Create a new Zendesk Ticket


### PR DESCRIPTION
- Ticket GET should use TicketResponse rather than Ticket struct type. 

Payload Example:
```JSON
{
	"ticket": {
		"url": "htttps://xxxxxx.zendesk.com/tickets/19.json",
		"id": 19,
		"external_id": null
.....
      }
}
```

Note: the embedded `ticket` in json payload. 

Current Expectation:

```JSON
{
	"url": "htttps://xxxxxx.zendesk.com/tickets/19.json",
	"id": 19,
	"external_id": null
.....
}
```