### PR TITLE
Fix TicketService.getPage()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ _testmain.go
 *.test
 config.yml
 config.yaml
+
+# Editor swap files
+*~
+*.swp

--- a/ticket.go
+++ b/ticket.go
@@ -230,7 +230,7 @@ func (s *TicketService) getPage(url string) ([]Ticket, *string, *Response, error
 		return nil, nil, nil, err
 	}
 
-	response := TicketCollectionResponse{}
+	response := &TicketCollectionResponse{}
 	resp, err := s.client.Do(req, response)
 	if err != nil {
 		return nil, nil, resp, err


### PR DESCRIPTION
`json.Unmarshal()` requires a reference, but we were passing it
a literal TicketCollectionResponse.